### PR TITLE
Add "What Is `std::string_view` and Why Should I Use It?"

### DIFF
--- a/articles/string-view.md
+++ b/articles/string-view.md
@@ -1,7 +1,6 @@
 # What Is `std::string_view` and Why Should I Use It?
 
 **[std::string_view][sv]**
-(alias for `std::basic_string_view<char>`)
 is a C++17 class which refers to a contiguous sequence of `char`s.
 You can think of it as a `const char*` and the string length,
 bundled together.
@@ -21,10 +20,11 @@ because it doesn't need null termination or dynamic memory allocation.
 and **[std::string][s]** can be implicitly converted to it,
 so **[std::string_view][sv]** is a drop-in replacement.
 
-## FAQ - Is `std::string` Useless in C++17?
+## When to use `std::string` vs. `std::string_view`
 
-No, **[std::string][s]** is still useful when you want to *store* a string,
-not just read its contents inside a function.
+**[std::string][s]** is useful when you want to *own* a string,
+not just read its contents.
+**[std::string_view][sv]** is a *non-owning view*.
 For example, **[std::string_view][sv]** cannot be used here:
 ```cpp
 // or when passing an rvalue reference
@@ -35,6 +35,7 @@ void store(std::string s) { this.s = std::move(s); }
 
 <:stackoverflow:1074747016644661258>
 [How exactly is std::string_view faster than const std::string&?](https://stackoverflow.com/q/40127965/5740428)
+- `!wiki ownership`
 
 [sv]: https://en.cppreference.com/w/cpp/string/basic_string_view
 [s]: https://en.cppreference.com/w/cpp/string/basic_string

--- a/articles/string-view.md
+++ b/articles/string-view.md
@@ -1,0 +1,40 @@
+# What Is `std::string_view` and Why Should I Use It?
+
+**[std::string_view][sv]**
+(alias for `std::basic_string_view<char>`)
+is a C++17 class which refers to a contiguous sequence of `char`s.
+You can think of it as a `const char*` and the string length,
+bundled together.
+
+It is a superior replacement for passing `const char*` or `const std::string&` parameters
+because it doesn't need null termination or dynamic memory allocation.
+
+## Use Case - Replace "Old" Strings
+
+```diff
+-void print(const char* message);
+-void print(const std::string& message);
++void print(std::string_view message);
+```
+**[std::string_view][sv]** has the same member functions as
+**[std::string][s]**,
+and **[std::string][s]** can be implicitly converted to it,
+so **[std::string_view][sv]** is a drop-in replacement.
+
+## FAQ - Is `std::string` Useless in C++17?
+
+No, **[std::string][s]** is still useful when you want to *store* a string,
+not just read its contents inside a function.
+For example, **[std::string_view][sv]** cannot be used here:
+```cpp
+// or when passing an rvalue reference
+void store(std::string s) { this.s = std::move(s); }
+```
+
+## See Also
+
+<:stackoverflow:1074747016644661258>
+[How exactly is std::string_view faster than const std::string&?](https://stackoverflow.com/q/40127965/5740428)
+
+[sv]: https://en.cppreference.com/w/cpp/string/basic_string_view
+[s]: https://en.cppreference.com/w/cpp/string/basic_string


### PR DESCRIPTION
While C++17 is quite old at this point, I still see a lot of beginners using `std::string` or even C-style strings, perhaps because their tutorials taught them to do that. We should have an article which explains what `std::string_view` is.

![image](https://github.com/user-attachments/assets/4a2736a9-e7f5-45c8-a47e-9dd6647bbf4a)

Note that this article is largely modeled after the `std::span` article.

Also note that the broken `:stackoverflow:` emote would work on TCCPP.