### PR TITLE
Add "What Is an Ill-Formed Program?" article

### DIFF
--- a/articles/ill-formed.md
+++ b/articles/ill-formed.md
@@ -1,0 +1,38 @@
+# What Is an Ill-Formed Program?
+
+An [ill-formed][ill-formed] program
+(as opposed to a [well-formed][well-formed] program)
+is "not valid standard C++".
+Compilers are required to raise a
+[diagnostic message][diagnostic message] (warning or error)
+when given an ill-formed program.
+
+<!-- inline -->
+## Ill-Formed Example A
+```cpp
+{#/;
+```
+Compilers should raise a syntax error here.
+
+<!-- inline -->
+## Ill-Formed Example B
+```cpp
+int a[0];
+```
+Zero-size arrays
+[are not allowed](https://eel.is/c++draft/dcl.array#1),
+but some compilers support them as an [extension][extension].
+
+## Ill-Formed, No Diagnostic Required (IFNDR)
+In some cases, the program is ill-formed,
+but diagnostics are not required
+(usually because it would take "heroic" compiler effort).
+For example, having a template which can never be instantiated makes a
+program [IFNDR][IFNDR].
+
+
+[diagnostic message]: https://eel.is/c++draft/defns.diagnostic
+[extension]: https://eel.is/c++draft/intro.compliance#general-9
+[ill-formed]: https://eel.is/c++draft/defns.ill.formed
+[well-formed]: https://eel.is/c++draft/defns.well.formed
+[IFNDR]: https://eel.is/c++draft/intro.compliance#general-2.2

--- a/articles/ill-formed.md
+++ b/articles/ill-formed.md
@@ -20,7 +20,7 @@ Compilers should raise a syntax error here.
 int a[0];
 ```
 Zero-size arrays
-[are not allowed](https://eel.is/c++draft/dcl.array#1),
+[are not allowed][zero size],
 but some compilers support them as an [extension][extension].
 
 ## Ill-Formed, No Diagnostic Required (IFNDR)
@@ -31,8 +31,9 @@ For example, having a template which can never be instantiated makes a
 program [IFNDR][IFNDR].
 
 
-[diagnostic message]: https://eel.is/c++draft/defns.diagnostic
-[extension]: https://eel.is/c++draft/intro.compliance#general-9
-[ill-formed]: https://eel.is/c++draft/defns.ill.formed
-[well-formed]: https://eel.is/c++draft/defns.well.formed
-[IFNDR]: https://eel.is/c++draft/intro.compliance#general-2.2
+[diagnostic message]: https://timsong-cpp.github.io/cppwp/n4950/defns.diagnostic
+[extension]: https://timsong-cpp.github.io/cppwp/n4950/intro.compliance.general#8
+[ill-formed]: https://timsong-cpp.github.io/cppwp/n4950/defns.ill.formed
+[well-formed]: https://timsong-cpp.github.io/cppwp/n4950/defns.well.formed
+[IFNDR]: https://timsong-cpp.github.io/cppwp/n4950/intro.compliance.general#2.2
+[zero size]: https://timsong-cpp.github.io/cppwp/n4950/dcl.array#1.sentence-3


### PR DESCRIPTION
Closes #1.

![image](https://github.com/user-attachments/assets/89e74a99-66c2-4d67-9038-15b342f06d27)

I have seen a question asking what it means for a program to be "ill-formed" twice in the last two days, and countless times overall now.

We have more than 1500 mentions of "ill-formed" on TCCPP and while articles usually aren't targeting language lawyers, this question is arguably common enough to make it into the FAQ. Explaining "ill-formed" in particular is also quite valuable because it's easy to think that "ill-formed = compiler error" when you pick the term up in casual use, without understanding what it actually means.