### PR TITLE
Add "Compiler Support" Article

### DIFF
--- a/articles/compiler-support.md
+++ b/articles/compiler-support.md
@@ -1,0 +1,19 @@
+# Compiler Support
+
+[The big listing of all C++ versions](<https://en.cppreference.com/w/cpp/compiler_support>)
+
+## Version Specific Support
+
+- [C++11](<https://en.cppreference.com/w/cpp/compiler_support/11>)
+- [C++14](<https://en.cppreference.com/w/cpp/compiler_support/14>)
+- [C++17](<https://en.cppreference.com/w/cpp/compiler_support/17>)
+- [C++20](<https://en.cppreference.com/w/cpp/compiler_support/20>)
+- [C++23](<https://en.cppreference.com/w/cpp/compiler_support/23>)
+- [C++26](<https://en.cppreference.com/w/cpp/compiler_support/26>)
+
+# Compiler Specific Links
+
+- [Clang](<https://clang.llvm.org/cxx_status.html>) (:tux:, :microsoft:)
+- [GCC](<https://gcc.gnu.org/projects/cxx-status.html>) (:tux:, MinGW)
+- [Apple Clang](<https://developer.apple.com/xcode/cpp/>) (:apple: :absolutely_proprietary:)
+- [MSVC](<https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=msvc-170>) (:microsoft:)

--- a/articles/compiler-support.md
+++ b/articles/compiler-support.md
@@ -11,7 +11,7 @@
 - [C++23](<https://en.cppreference.com/w/cpp/compiler_support/23>)
 - [C++26](<https://en.cppreference.com/w/cpp/compiler_support/26>)
 
-# Compiler Specific Links
+## Compiler Specific Links
 
 - [Clang](<https://clang.llvm.org/cxx_status.html>) (:tux:, :microsoft:)
 - [GCC](<https://gcc.gnu.org/projects/cxx-status.html>) (:tux:, MinGW)


### PR DESCRIPTION
[<img width="219" alt="Screenshot 2024-10-30 at 21 17 50" src="https://github.com/user-attachments/assets/b9242695-1ff2-4374-be0c-f76916c04dfc">](https://discord.com/channels/331718482485837825/506274405500977153/1301389845113081957)


This is a small wiki article to link to every C++ compiler support page from cppreference, and to the specific documentation links for Clang, GCC, MSVC, and Apple Clang.

Would close https://discord.com/channels/331718482485837825/1297035168774750270