### PR TITLE
Compactify and further improve compiler support article

### DIFF
--- a/articles/compiler-support.md
+++ b/articles/compiler-support.md
@@ -1,8 +1,9 @@
 # Compiler Support
 
-[The big listing of all C++ versions](<https://en.cppreference.com/w/cpp/compiler_support>)
+Links to: [all C++ versions][cpp], and [all C versions][c]
 
-## Version Specific Support
+<!-- inline -->
+## :link: Version-Specific Links
 
 - [C++11](<https://en.cppreference.com/w/cpp/compiler_support/11>)
 - [C++14](<https://en.cppreference.com/w/cpp/compiler_support/14>)
@@ -10,10 +11,16 @@
 - [C++20](<https://en.cppreference.com/w/cpp/compiler_support/20>)
 - [C++23](<https://en.cppreference.com/w/cpp/compiler_support/23>)
 - [C++26](<https://en.cppreference.com/w/cpp/compiler_support/26>)
+- [C23](<https://en.cppreference.com/w/c/compiler_support/23>)
 
-## Compiler Specific Links
+<!-- inline -->
+## :link: Compiler-Specific Links
 
 - [Clang](<https://clang.llvm.org/cxx_status.html>) (:tux:, :microsoft:)
 - [GCC](<https://gcc.gnu.org/projects/cxx-status.html>) (:tux:, MinGW)
 - [Apple Clang](<https://developer.apple.com/xcode/cpp/>) (:apple: :absolutely_proprietary:)
 - [MSVC](<https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance?view=msvc-170>) (:microsoft:)
+
+
+[c]: https://en.cppreference.com/w/c/compiler_support
+[cpp]: https://en.cppreference.com/w/cpp/compiler_support

--- a/articles/compiler-support.md
+++ b/articles/compiler-support.md
@@ -11,6 +11,7 @@ Links to: [all C++ versions][cpp], and [all C versions][c]
 - [C++20](<https://en.cppreference.com/w/cpp/compiler_support/20>)
 - [C++23](<https://en.cppreference.com/w/cpp/compiler_support/23>)
 - [C++26](<https://en.cppreference.com/w/cpp/compiler_support/26>)
+- [C99](<https://en.cppreference.com/w/c/compiler_support/99>)
 - [C23](<https://en.cppreference.com/w/c/compiler_support/23>)
 
 <!-- inline -->


### PR DESCRIPTION
Implements the suggestions made on #15 and further improves the article by adding links to C.

Preview: https://discord.com/channels/331718482485837825/801161716213219348/1304911724880728225
![image](https://github.com/user-attachments/assets/f90375e3-9b56-4a99-a456-26930b823959)
(Emotes would work on TCCPP)