### PR TITLE
Revert words of advice on debuggers in `learn-c` and `learn-cpp`

### DIFF
--- a/articles/learn-c.md
+++ b/articles/learn-c.md
@@ -24,8 +24,3 @@ We *strongly* recommend to start out using an IDE, which will provide all these 
 ## :apple: Mac
 - [Xcode](https://developer.apple.com/xcode/)
 - [CLion](https://www.jetbrains.com/clion/)
-
-## Words of Advice
-> The wise programmer is told about the debugger and uses it.
-> The average programmer is told about the debugger and avoids it.
-> The foolish programmer is told about the debugger and laughs at it.

--- a/articles/learn-cpp.md
+++ b/articles/learn-cpp.md
@@ -23,8 +23,3 @@ We *strongly* recommend to start out using an IDE, which will provide all these 
 ## :apple: Mac
 - [Xcode](https://developer.apple.com/xcode/)
 - [CLion](https://www.jetbrains.com/clion/)
-
-## Words of Advice
-> The wise programmer is told about the debugger and uses it.
-> The average programmer is told about the debugger and avoids it.
-> The foolish programmer is told about the debugger and laughs at it.


### PR DESCRIPTION
Implements the agreed-upon changes in https://github.com/TCCPP/wheatley/issues/64.

To be honest, I got really burned out back when we discussed that Wheatley issue, and I didn't want anything to do with it anymore. It still bothers me and @64 said to remove it, so let's just do that.