### PR TITLE
Add member initializer list article

### DIFF
--- a/articles/member-init.md
+++ b/articles/member-init.md
@@ -1,0 +1,31 @@
+# What Is a "Member Initalizer List" And Why Should I Use It?
+
+A [member initializer list][cppref] in a constructor initializes the data members
+of a class:
+```cpp
+struct S {
+  int x, y;
+  // initializes data member 'x' to parameter 'x',
+  // and initializes data member 'y' to zero
+  S(int x) : x(x), y(0) { }
+};
+```
+:warning: Initialization happens in the order of data members;
+the member initializer list `y(0), x(x)` would be equivalent but misleading.
+
+A common mistake is to leave data members uninitialized and then assign them
+in the constructor.
+For trivial types like `int`, this works, but it can lead to bad performance
+for larger types, or result in an error:
+```cpp
+struct C {
+  const int y; // error: uninitialized const member
+  C(int y) { this->y = y; } // error: assigning to const
+};
+```
+
+## See Also
+<:tccpp:865354975629279232>
+[Learn more about member initializer lists](https://64.github.io/cpp-faq/member-initializer-list/)
+
+[cppref]: https://en.cppreference.com/w/cpp/language/constructor#Member_initializer_list

--- a/articles/member-init.md
+++ b/articles/member-init.md
@@ -19,8 +19,8 @@ For trivial types like `int`, this works, but it can lead to bad performance
 for larger types, or result in an error:
 ```cpp
 struct C {
-  const int y; // error: uninitialized const member
-  C(int y) { this->y = y; } // error: assigning to const
+  const int z; // error: uninitialized const member
+  C(int z) { this->z = z; } // error: assigning to const
 };
 ```
 


### PR DESCRIPTION
We have https://64.github.io/cpp-faq/member-initializer-list/, but barely anyone uses it.

Beginners writing `this->x = x` in constructors is still a super common anti-pattern, and asking what a member initializer list is a super common follow-up question when someone makes that recommendation. We should just have a wiki article for this; it would be easier.