### PR TITLE
Article about why templates must be in header files

### DIFF
--- a/articles/template-header.md
+++ b/articles/template-header.md
@@ -4,22 +4,25 @@ When a template is used, the compiler instantiates it by substituting template a
 
 The compiler needs to have access to the implementation of the class methods or the function to instantiate them with the template argument. If these implementations were not in the header, they wouldn't be accessible, and therefore the compiler wouldn't be able to instantiate the template.
 
+```cpp
+// foo.hpp
+template<typename T>
+T add(T a, T b);
+// foo.cpp
+#include "foo.hpp"
+template<typename T>
+T add(T a, T b) {
+    return a + b;
+}
+// bar.cpp
+#include "foo.hpp"
+int bar(int a, int b) {
+    // references add<int> but the compiler can't instantiate this since it doesn't have the definition
+    return add(a, b);
+}
+```
+
 ## Alternative solution
 
 Another solution is to keep the implementation separated, and explicitly instantiate all the template instances you'll need.
 
-```cpp
-//foo.hpp
-//no method implementations
-template <typename T> struct Foo { ... };
-```
-
-```cpp
-//foo.cpp
-//implementation of Foo's methods here...
-
-//explicitly instantiate Foo<T> with the needed template arguments
-//you will only be able to use Foo with T=int and T=float
-template class Foo<int>;
-template class Foo<float>;
-```

--- a/articles/template-header.md
+++ b/articles/template-header.md
@@ -1,8 +1,6 @@
 # Why can templates only be implemented in the header file?
 
-The only portable way of using templates at the moment is to implement them in header files by using inline functions.
-
-When instantiating a template, the compiler creates a new class/function with the given template argument.
+When a template is used, the compiler instantiates it by substituting template arguments in the function, class, struct, etc. Because the compiler must have the definition of the function, class, or struct available at the point of instantiation it doesn't work to split templates between C++ header files and .cpp files as is traditionally done for functions, classes, and structs.
 
 The compiler needs to have access to the implementation of the class methods or the function to instantiate them with the template argument. If these implementations were not in the header, they wouldn't be accessible, and therefore the compiler wouldn't be able to instantiate the template.
 

--- a/articles/template-header.md
+++ b/articles/template-header.md
@@ -1,0 +1,27 @@
+# Why can templates only be implemented in the header file?
+
+The only portable way of using templates at the moment is to implement them in header files by using inline functions.
+
+When instantiating a template, the compiler creates a new class/function with the given template argument.
+
+The compiler needs to have access to the implementation of the class methods or the function to instantiate them with the template argument. If these implementations were not in the header, they wouldn't be accessible, and therefore the compiler wouldn't be able to instantiate the template.
+
+## Alternative solution
+
+Another solution is to keep the implementation separated, and explicitly instantiate all the template instances you'll need.
+
+```cpp
+//foo.hpp
+//no method implementations
+template <typename T> struct Foo { ... };
+```
+
+```cpp
+//foo.cpp
+//implementation of Foo's methods here...
+
+//explicitly instantiate Foo<T> with the needed template arguments
+//you will only be able to use Foo with T=int and T=float
+template class Foo<int>;
+template class Foo<float>;
+```


### PR DESCRIPTION
Seen this issue countless times in `#cpp-help`, didn't see an article similar to it.