### PR TITLE
Update article on UB

### DIFF
--- a/articles/ub.md
+++ b/articles/ub.md
@@ -2,9 +2,14 @@
 
 # Undefined Behavior
 
-Undefined behavior (UB) occurs when you violate rules specified by the language.
-For example: Reading uninitialized memory, performing out-of-bounds memory access,
-or using an object after it no longer exists.
+Undefined behavior (UB) is behavior for which C++ imposes no requirements.
+This could mean that your code crashes,
+isn't executed when it should be,
+or does other unexpected things.
+
+Typical causes are: reading uninitialized memory,
+performing out-of-bounds memory access,
+or using an object when it no longer exists.
 
 <!-- inline -->
 ## Example: Indeterminate Value
@@ -14,20 +19,24 @@ while(i < 10) {
     printf("%d\n", i++);
 }
 ```
+-# Note: Since C++26,
+this code has erroneous behavior, not undefined behavior.
 
 <!-- inline -->
 ## Example: Out-of-Bounds Access
 ```cpp
 int arr[10];
-for(int i = 0; i < 20; i++) {
+for(int i = 0; i<20; i++) {
     arr[i] = 0;
 }
 ```
 
 ## Why it Matters
 
-Compilers often do not give warnings or errors about UB and its existence in your code can cause surprising,
-unpredictable, and buggy behavior.
+Compilers often do not give warnings or errors about UB,
+and its existence in your code can cause surprising,
+unpredictable, and buggy behavior,
+which may even result in security vulnerabilities.
 
 ## See Also
 

--- a/articles/ub.md
+++ b/articles/ub.md
@@ -25,8 +25,8 @@ this code has erroneous behavior, not undefined behavior.
 <!-- inline -->
 ## Example: Out-of-Bounds Access
 ```cpp
-int arr[10];
-for(int i = 0; i<20; i++) {
+int arr[4];
+for(int i = 0; i < 8; i++) {
     arr[i] = 0;
 }
 ```


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8421cd60-0378-4b31-acac-cb10c16c2039)

This update makes the embed slightly larger, but I think the real estate is well-spent. The improvements include:

- Replacing "violate rules specified by the language". @michael-kenzel pointed this out suboptimal, and I hate to agree. Violating language rules could mean IF, IFNDR, optional warnings, or any number of things. It's better to stick closer to standardese but provide tangible examples of how "no requirements" manifests itself.
- The example in indeterminate values has not aged well. I think it's worth keeping it as it's a super-common example of UB, but the C++26 clarification makes it correct.
- After Discord updated its CSS, `i < 20` is too wide and result in code wrapping.
- The old article made no mention of security/safety, which is a big hole in the article, considering how much safety has entered the C++ Zeitgeist.